### PR TITLE
Work around: mispronunciation of right single quotation mark

### DIFF
--- a/src/com/hyperionics/fbreader/plugin/tts_plus/TtsSentenceExtractor.java
+++ b/src/com/hyperionics/fbreader/plugin/tts_plus/TtsSentenceExtractor.java
@@ -102,6 +102,9 @@ public class TtsSentenceExtractor {
                 w = w.replace('\u2013', '-'); // dec 8211, "en dash" or long dash, Ivona PL reads as "przecinek"
                 w = w.replace('\u2014', '-'); // dec 8211, 'EM DASH', Ivona PL reads as "przecinek"
                 w = w.replace('\u00A0', ' '); // dec 160, no-break space
+
+                w = w.replace('\u2019', '\''); // dec 8217, right single quotation mark, see https://code.google.com/p/android/issues/detail?id=38258
+
                 if (w.charAt(0) == '\u2026')  // dec 8230 ellipses ... remove at start
                     w = " " + w.substring(1);
                 w = replaceAbbreviations(w, loc);


### PR DESCRIPTION
The default android TTS engine on 4.2 has trouble pronouncing 
the UTF-8 character for single right quotation marks, see  
https://code.google.com/p/android/issues/detail?id=38258

As a workaround we can replace the right single quotation mark 
with an ASCII single quotation mark.
